### PR TITLE
Add testing for bazel action tests

### DIFF
--- a/.github/workflows/test_upload_impacted_targets_bazel_startup_options_bazel.yaml
+++ b/.github/workflows/test_upload_impacted_targets_bazel_startup_options_bazel.yaml
@@ -1,0 +1,25 @@
+name: Upload Impacted Targets - bazel startup options (bazel-action)
+run-name: Upload Impacted Targets for ${{ github.ref_name }} (bazel-action)
+on: pull_request
+
+jobs:
+  compute_impacted_targets:
+    name: Compute Impacted Targets (with startup options)
+    if: startsWith(github.head_ref, 'impacted_targets_test/bazel_startup_options_bazel/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Compute Impacted Targets (with startup options) (bazel-action)
+        # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
+        uses: trunk-io/bazel-action@main
+        with:
+          trunk-token: ${{ secrets.TRUNK_REPO_API_TOKEN }}
+          bazel-workspace-path: test_workspace
+          verbose: 1
+          bazel-startup-options: --host_jvm_args=-Xmx12G,--block_for_lock,--client_debug
+        env:
+          API_URL: https://api.trunk-staging.io:443/v1/setImpactedTargets

--- a/.github/workflows/test_upload_impacted_targets_bazel_startup_options_bazel.yaml
+++ b/.github/workflows/test_upload_impacted_targets_bazel_startup_options_bazel.yaml
@@ -17,6 +17,8 @@ jobs:
         # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
         uses: trunk-io/bazel-action@main
         with:
+          upload-targets: "true"
+          test-targets: "false"
           trunk-token: ${{ secrets.TRUNK_REPO_API_TOKEN }}
           bazel-workspace-path: test_workspace
           verbose: 1

--- a/.github/workflows/test_upload_impacted_targets_bazel_startup_options_bazel.yaml
+++ b/.github/workflows/test_upload_impacted_targets_bazel_startup_options_bazel.yaml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   compute_impacted_targets:
-    name: Compute Impacted Targets (with startup options)
+    name: Compute Impacted Targets (with startup options) (bazel-action)
     if: startsWith(github.head_ref, 'impacted_targets_test/bazel_startup_options_bazel/')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_upload_impacted_targets_non_verbose_bazel.yaml
+++ b/.github/workflows/test_upload_impacted_targets_non_verbose_bazel.yaml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   compute_impacted_targets:
-    name: Compute Impacted Targets (non VERBOSE)
+    name: Compute Impacted Targets (non VERBOSE) (bazel-action)
     if: startsWith(github.head_ref, 'impacted_targets_test/non_verbose_bazel/')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_upload_impacted_targets_non_verbose_bazel.yaml
+++ b/.github/workflows/test_upload_impacted_targets_non_verbose_bazel.yaml
@@ -1,0 +1,23 @@
+name: Upload Impacted Targets - non verbose (bazel-action)
+run-name: Upload Impacted Targets for ${{ github.ref_name }} (bazel-action)
+on: pull_request
+
+jobs:
+  compute_impacted_targets:
+    name: Compute Impacted Targets (non VERBOSE)
+    if: startsWith(github.head_ref, 'impacted_targets_test/non_verbose_bazel/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Compute Impacted Targets (non VERBOSE) (bazel-action)
+        # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
+        uses: trunk-io/bazel-action@main
+        with:
+          trunk-token: ${{ secrets.TRUNK_REPO_API_TOKEN }}
+          bazel-workspace-path: test_workspace
+        env:
+          API_URL: https://api.trunk-staging.io:443/v1/setImpactedTargets

--- a/.github/workflows/test_upload_impacted_targets_non_verbose_bazel.yaml
+++ b/.github/workflows/test_upload_impacted_targets_non_verbose_bazel.yaml
@@ -17,6 +17,8 @@ jobs:
         # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
         uses: trunk-io/bazel-action@main
         with:
+          upload-targets: "true"
+          test-targets: "false"
           trunk-token: ${{ secrets.TRUNK_REPO_API_TOKEN }}
           bazel-workspace-path: test_workspace
         env:

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -2,7 +2,7 @@
 *logs
 *actions
 *notifications
+*tools
 plugins
 user_trunk.yaml
 user.yaml
-shims

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,20 +1,20 @@
 version: 0.1
 cli:
-  version: 1.11.1
+  version: 1.17.1
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.20
+      ref: v1.2.6
       uri: https://github.com/trunk-io/plugins
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.3
+      ref: v0.0.8
 lint:
   enabled:
     - git-diff-check
-    - markdownlint@0.35.0
-    - prettier@2.8.8
-    - trufflehog@3.40.0
+    - markdownlint@0.37.0
+    - prettier@3.0.3
+    - trufflehog@3.60.0
 runtimes:
   enabled:
     - node@18.12.1


### PR DESCRIPTION
Duplicates the logic and assertions for `test_upload_impacted_targets_bazel_startup_options` and `test_upload_impacted_targets_non_verbose`. Paired with https://github.com/trunk-io/trunk/pull/11419.